### PR TITLE
gitignore should include mirage.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ ukvm/ukvm
 kernel/kernel
 kernel/interrupt_vectors.s
 disk.img
+mirage.mk


### PR DESCRIPTION
.gitignore should include mirage.mk as it is autogenerated.