### PR TITLE
Initialise BOOT_PDPTE to zero

### DIFF
--- a/ukvm/ukvm.c
+++ b/ukvm/ukvm.c
@@ -357,7 +357,7 @@ static void setup_system_page_tables(struct kvm_sregs *sregs, uint8_t * mem)
     uint64_t *pdpte = (uint64_t *) (mem + BOOT_PDPTE);
 
     memset(mem + BOOT_PML4, 0, 4096);
-    memset(mem + BOOT_PML4, 0, 4096);
+    memset(mem + BOOT_PDPTE, 0, 4096);
 
     *pml4 = BOOT_PDPTE | 3;
     *pdpte = 0x83;


### PR DESCRIPTION
Not strictly required as the mmap()ed guest memory block should be
initialised to all zeroes, but we don't want to rely on that.