### PR TITLE
Namespace solo5 APIs, migrate to ocaml-freestanding runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ opam-virtio-install: solo5-kernel-virtio.pc virtio_target
 	cp iso/boot/grub/menu.lst $(OPAM_VIRTIO_LIBDIR)
 	cp iso/boot/grub/stage2_eltorito $(OPAM_VIRTIO_LIBDIR)
 	cp kernel/virtio/solo5.o kernel/virtio/solo5.lds $(OPAM_VIRTIO_LIBDIR)
+	mkdir -p $(PREFIX)/lib/pkgconfig
 	cp solo5-kernel-virtio.pc $(PREFIX)/lib/pkgconfig
 
 .PHONY: opam-virtio-uninstall
@@ -99,7 +100,9 @@ opam-ukvm-install: solo5-kernel-ukvm.pc ukvm_target
 	cp kernel/solo5.h $(OPAM_UKVM_INCDIR)/solo5.h
 	cp ukvm/ukvm.h $(OPAM_UKVM_INCDIR)/ukvm.h
 	cp kernel/ukvm/solo5.o kernel/ukvm/solo5.lds $(OPAM_UKVM_LIBDIR)
+	mkdir -p $(OPAM_BINDIR)
 	cp ukvm/ukvm $(OPAM_BINDIR)
+	mkdir -p $(PREFIX)/lib/pkgconfig
 	cp solo5-kernel-ukvm.pc $(PREFIX)/lib/pkgconfig
 
 .PHONY: opam-ukvm-uninstall

--- a/Makefile
+++ b/Makefile
@@ -67,19 +67,21 @@ OPAM_UKVM_INCDIR=$(PREFIX)/include/solo5-kernel-ukvm/include
 OPAM_VIRTIO_LIBDIR=$(PREFIX)/lib/solo5-kernel-virtio
 OPAM_VIRTIO_INCDIR=$(PREFIX)/include/solo5-kernel-virtio/include
 
-# We want the MD CFLAGS in the .pc file, where they can be
-# (eventually) picked up by the Mirage tool. XXX We may want to pick
-# LDLIBS and LDFLAGS also.
+# We want the MD CFLAGS, LDFLAGS and LDLIBS in the .pc file, where they can be
+# picked up by the Mirage tool / other downstream consumers.
 KERNEL_MD_CFLAGS=$(shell make -sC kernel print-md-cflags)
+KERNEL_LDFLAGS=$(shell make -sC kernel print-ldflags)
+KERNEL_LDLIBS=$(shell make -sC kernel print-ldlibs)
 %.pc: %.pc.in 
 	sed <$< > $@ \
-	    -e 's#!CFLAGS!#$(KERNEL_MD_CFLAGS)#g;'
+	    -e 's#!CFLAGS!#$(KERNEL_MD_CFLAGS)#g;' \
+	    -e 's#!LDFLAGS!#$(KERNEL_LDFLAGS)#g;' \
+	    -e 's#!LDLIBS!#$(KERNEL_LDLIBS)#g;'
 
 .PHONY: opam-virtio-install
-# TODO: solo5.h and ukvm.h should only contain public APIs.
 opam-virtio-install: solo5-kernel-virtio.pc virtio_target
 	mkdir -p $(OPAM_VIRTIO_INCDIR) $(OPAM_VIRTIO_LIBDIR)
-	cp kernel/kernel.h $(OPAM_VIRTIO_INCDIR)/solo5.h
+	cp kernel/solo5.h $(OPAM_VIRTIO_INCDIR)/solo5.h
 	cp loader/loader $(OPAM_VIRTIO_LIBDIR)
 	cp iso/boot/grub/menu.lst $(OPAM_VIRTIO_LIBDIR)
 	cp iso/boot/grub/stage2_eltorito $(OPAM_VIRTIO_LIBDIR)
@@ -92,10 +94,9 @@ opam-virtio-uninstall:
 	rm -f $(PREFIX)/lib/pkgconfig/solo5-kernel-virtio.pc
 
 .PHONY: opam-ukvm-install
-# TODO: solo5.h and ukvm.h should only contain public APIs.
 opam-ukvm-install: solo5-kernel-ukvm.pc ukvm_target
 	mkdir -p $(OPAM_UKVM_INCDIR) $(OPAM_UKVM_LIBDIR)
-	cp kernel/kernel.h $(OPAM_UKVM_INCDIR)/solo5.h
+	cp kernel/solo5.h $(OPAM_UKVM_INCDIR)/solo5.h
 	cp ukvm/ukvm.h $(OPAM_UKVM_INCDIR)/ukvm.h
 	cp kernel/ukvm/solo5.o kernel/ukvm/solo5.lds $(OPAM_UKVM_LIBDIR)
 	cp ukvm/ukvm $(OPAM_BINDIR)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -18,6 +18,7 @@
 AS=as
 CC=gcc
 LD=ld
+OBJCOPY=objcopy
 # Ensure no host headers or libraries are used when building, with the
 # exception of:
 #   - Standard C headers required by C89/C99. -nostdinc removes access to these
@@ -104,9 +105,11 @@ interrupt_vectors.s: interrupts.h
 
 virtio/solo5.o: $(VIRTIO_COBJS) $(SOBJS) virtio/solo5.lds
 	$(LD) -r $(LDFLAGS) -o $@ $(VIRTIO_COBJS) $(SOBJS) 
+	$(OBJCOPY) -w -G solo5_\* -G kernel_main $@ $@
 
 ukvm/solo5.o: $(UKVM_COBJS) $(SOBJS) ukvm/solo5.lds
 	$(LD) -r $(LDFLAGS) -o $@ $(UKVM_COBJS) $(SOBJS) 
+	$(OBJCOPY) -w -G solo5_\* -G kernel_main $@ $@
 
 .PHONY: clean
 clean:

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -120,3 +120,10 @@ clean:
 print-md-cflags:
 	@echo $(MD_CFLAGS)
 
+.PHONY: print-ldflags
+print-ldflags:
+	@echo $(LDFLAGS)
+
+.PHONY: print-ldlibs
+print-ldlibs:
+	@echo $(LDLIBS)

--- a/kernel/ee_printf.c
+++ b/kernel/ee_printf.c
@@ -990,17 +990,6 @@ int printf(const char *fmt, ...){
     return ret;
 }
 
-int printk(const char *fmt, ...){
-    va_list args;
-    int ret;
-
-    va_start(args, fmt);
-    ret = ee_vprintf(fmt, args);
-    va_end(args);
-
-    return ret;
-}
-
 int fprintf(void *stream __attribute__((__unused__)), const char *fmt, ...){
     va_list args;
     int ret;
@@ -1018,17 +1007,6 @@ int snprintf(char *str, size_t size, const char *fmt, ...){
 	
     va_start(args, fmt);
     ret = vsnprintf(str, size, fmt, args);
-    va_end(args);
-
-    return ret;
-}
-
-int sprintf(char *str, const char *fmt, ...){
-    va_list args;
-	int ret;
-	
-    va_start(args, fmt);
-    ret = vsnprintf(str, SIZE_MAX, fmt, args);
     va_end(args);
 
     return ret;

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -19,6 +19,8 @@
 #ifndef __KERNEL_H__
 #define __KERNEL_H__
 
+#include "solo5.h"
+
 /* This is the main header file for everything in the kernel */
 
 
@@ -57,7 +59,7 @@
 #define STR(x) STR_EXPAND(x)
 
 /* kernel.s: hang kernel, or hlt for interrupts */
-void kernel_hang(void);
+void kernel_hang(void) __attribute__((noreturn));
 void kernel_wait(void);
 void kernel_waitloop(void);
 void kernel_busyloop(void);
@@ -85,24 +87,10 @@ uint64_t time_counts_since_startup(void);
 void increment_time_count(void);
 int sleep(uint32_t seconds);
 
-/* printk.c: only has a few options: 
- *  %c   : character
- *  %s   : string
- *  %d   : int32_t in decimal
- *  %b   : uint8_t in hex
- *  %x   : uint16_t in hex
- *  %lx  : uint32_t in hex
- *  %llx : uint64_t in hex 
- */
-//void printk(char *fmt, ...);
-
-
 /* ee_printf.c: a third-party printf slightly modified and with
  *              snprintf added 
  */
-int printk(const char *fmt, ...);
 int printf(const char *fmt, ...);
-int sprintf(char *str, const char *format, ...);
 int snprintf(char *str, size_t size, const char *format, ...);
 int vsnprintf(char *buf, size_t size, const char *fmt, va_list args);
 
@@ -130,16 +118,6 @@ extern uint8_t virtio_net_mac[];
 uint8_t *virtio_net_pkt_get(int *size);  /* get a pointer to recv'd data */
 void virtio_net_pkt_put(void);      /* we're done with recv'd data */
 int virtio_net_xmit_packet(void *data, int len);
-int solo5_net_write_sync(uint8_t *data, int n);
-int solo5_net_read_sync(uint8_t *data, int *n);
-char *solo5_net_mac_str(void);
-
-/* block interface */
-int solo5_blk_write_sync(uint64_t sec, uint8_t *data, int n);
-int solo5_blk_read_sync(uint64_t sec, uint8_t *data, int *n);
-int solo5_blk_sector_size(void);
-uint64_t solo5_blk_sectors(void);
-int solo5_blk_rw(void);
 
 void handle_virtio_interrupt(void);
 

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -250,23 +250,6 @@ void  free(void *ptr);
 void *sbrk(intptr_t increment);
 void* memalign(size_t alignment, size_t bytes);
 
-inline void
-x86_cpuid(uint32_t level, uint32_t *eax_out, uint32_t *ebx_out,
-		uint32_t *ecx_out, uint32_t *edx_out)
-{
-	uint32_t eax_, ebx_, ecx_, edx_;
-
-	__asm__(
-		"cpuid"
-		: "=a" (eax_), "=b" (ebx_), "=c" (ecx_), "=d" (edx_)
-		: "0" (level)
-	);
-	*eax_out = eax_;
-	*ebx_out = ebx_;
-	*ecx_out = ecx_;
-	*edx_out = edx_;
-}
-
 #define MSEC_PER_SEC    1000
 #define NSEC_PER_SEC	1000000000ULL
 

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -193,6 +193,8 @@ static inline uint64_t inq(uint16_t port_lo){
     return ((uint64_t)lo) | ((uint64_t)hi << 32);
 }
 
+/* compiler-only memory "barrier" */
+#define cc_barrier() __asm__ __volatile__("": : :"memory")
 
 #define PANIC(x...) do {                                   \
         printf("PANIC: %s:%d\n", __FILE__, __LINE__);      \

--- a/kernel/malloc.c
+++ b/kernel/malloc.c
@@ -6280,3 +6280,9 @@ History:
          structure of old version,  but most details differ.)
 
 */
+
+/* Export public interfaces defined in this file */
+void *solo5_malloc(size_t) __attribute__ ((alias ("malloc")));
+void solo5_free(void *) __attribute__ ((alias ("free")));
+void *solo5_calloc(size_t, size_t) __attribute__ ((alias ("calloc")));
+void *solo5_realloc(void *, size_t) __attribute__ ((alias ("realloc")));

--- a/kernel/solo5.h
+++ b/kernel/solo5.h
@@ -1,1 +1,37 @@
-kernel.h
+#ifndef SOLO5_H_INCLUDED
+#define SOLO5_H_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Solo5 public APIs */
+
+/* Network */
+int solo5_net_write_sync(uint8_t *data, int n);
+int solo5_net_read_sync(uint8_t *data, int *n);
+char *solo5_net_mac_str(void);
+
+/* Block */
+int solo5_blk_write_sync(uint64_t sec, uint8_t *data, int n);
+int solo5_blk_read_sync(uint64_t sec, uint8_t *data, int *n);
+int solo5_blk_sector_size(void);
+uint64_t solo5_blk_sectors(void);
+int solo5_blk_rw(void);
+
+/* Console */
+int solo5_console_write(const char *buf, size_t n);
+
+/* Exit */
+void solo5_exit(void) __attribute__((noreturn));
+
+/* Memory allocation */
+void *solo5_malloc(size_t);
+void solo5_free(void *);
+void *solo5_calloc(size_t, size_t);
+void *solo5_realloc(void *, size_t);
+
+/* Time */
+uint64_t solo5_clock_monotonic(void);
+uint64_t solo5_clock_wall(void);
+
+#endif

--- a/kernel/stubs.c
+++ b/kernel/stubs.c
@@ -18,55 +18,9 @@
 
 #include "kernel.h"
 
-#define IGNORE(x...) do {                                       \
-        printf("IGNORING: ");                                   \
-        printf(x);                                              \
-    } while (0)
-
-int errno;
-
-void init_events(void) { IGNORE("init_events\n"); }
-void setup_xen_features(void) { IGNORE("setup_xen_features\n"); }
-void init_mm(void) { IGNORE("init_mm\n"); }
-void init_time(void) { IGNORE("init_time\n"); }
-void init_console(void) { IGNORE("init_console\n"); }
-void init_gnttab(void) { IGNORE("init_gnttab\n"); }
-
-void console_print(void *dev __attribute__((__unused__)), 
-                   char *data, 
-                   int length __attribute__((__unused__))){
-    printf(data);
-}
-
-void *_xmalloc(size_t size, size_t align) {
-    return memalign(align, size);
-}
-void do_exit(void) {
-    low_level_exit();
+void solo5_exit(void)
+{
     printf("Mirage on Solo5 exiting... Goodbye!\n");
+    low_level_exit();
     kernel_hang();
 }
-
-/* The definition of struct timeval should be in a header file, but
- * some libraries are still taking the native (system) time.h causing
- * a redefinition.  So for now, we define this here, although it's
- * fragile and a recipe for disaster.  It's also in clock_stubs.c from
- * mirage-platform.  */
-struct timeval {
-    long tv_sec;
-    long tv_usec;
-};
-
-#define NSEC_TO_USEC(_nsec)     ((_nsec) / 1000UL)
-#define NSEC_TO_MSEC(_nsec)     ((_nsec) / 1000000ULL)
-#define NSEC_TO_SEC(_nsec)      ((_nsec) / 1000000000ULL)
-
-int gettimeofday(struct timeval *tv, __attribute__((__unused__)) void *tz) {
-    uint64_t nsec = time_monotonic_ns();
-
-    tv->tv_sec = NSEC_TO_SEC(nsec);
-    tv->tv_usec = NSEC_TO_USEC(nsec % 1000000000UL);
-
-    return 0;
-}
-

--- a/kernel/test_hello.c
+++ b/kernel/test_hello.c
@@ -1,7 +1,9 @@
-#include "kernel.h"
+#include "solo5.h"
 
 void start_kernel(void)
 {
-    printf("Hello, World!\n");
+    const char s[] = "Hello, World\n";
+
+    solo5_console_write(s, sizeof s);
 }
 

--- a/kernel/test_ping_serve.c
+++ b/kernel/test_ping_serve.c
@@ -1,9 +1,13 @@
-#include "kernel.h"
+#include "solo5.h"
+
+extern void solo5_ping_serve(void); /* XXX */
 
 void start_kernel(void)
 {
-    printf("Hello World\n");
-    for(;;)
-        ping_serve();  /* does things if network packet comes in */
-}
+    const char s[] = "Hello, World\n";
 
+    solo5_console_write(s, sizeof s);
+
+    for(;;)
+        solo5_ping_serve();  /* does things if network packet comes in */
+}

--- a/kernel/time.c
+++ b/kernel/time.c
@@ -27,6 +27,23 @@
 
 #include "kernel.h"
 
+static inline void
+x86_cpuid(uint32_t level, uint32_t *eax_out, uint32_t *ebx_out,
+        uint32_t *ecx_out, uint32_t *edx_out)
+{
+    uint32_t eax_, ebx_, ecx_, edx_;
+
+    __asm__(
+        "cpuid"
+        : "=a" (eax_), "=b" (ebx_), "=c" (ecx_), "=d" (edx_)
+        : "0" (level)
+    );
+    *eax_out = eax_;
+    *ebx_out = ebx_;
+    *ecx_out = ecx_;
+    *edx_out = edx_;
+}
+
 typedef unsigned long long bmk_time_t;
 
 bmk_time_t rtc_epochoffset;
@@ -96,9 +113,9 @@ int pvclock_init(void) {
     }
     else {
         return 1;
-        }
+    }
 
-        printf("Initializing the KVM Paravirtualized clock.\n");
+    printf("Initializing the KVM Paravirtualized clock.\n");
 
     __asm__ __volatile("wrmsr" ::
         "c" (msr_kvm_system_time),

--- a/kernel/ukvm/io.c
+++ b/kernel/ukvm/io.c
@@ -2,79 +2,96 @@
 
 /* ukvm net interface */
 int solo5_net_write_sync(uint8_t *data, int n) {
-	volatile struct ukvm_netwrite wr;
+    volatile struct ukvm_netwrite wr;
 
-	wr.data = data;
-	wr.len = n;
-	wr.ret = 0;
-	
-	outl(UKVM_PORT_NETWRITE, ukvm_ptr(&wr));
-    
+    wr.data = data;
+    wr.len = n;
+    wr.ret = 0;
+
+    outl(UKVM_PORT_NETWRITE, ukvm_ptr(&wr));
+    cc_barrier();
+
     return wr.ret;
 }
+
 int solo5_net_read_sync(uint8_t *data, int *n) {
-	volatile struct ukvm_netread rd;
+    volatile struct ukvm_netread rd;
 
-	rd.data = data;
-	rd.len = *n;
-	rd.ret = 0;
-		
-	outl(UKVM_PORT_NETREAD, ukvm_ptr(&rd));
+    rd.data = data;
+    rd.len = *n;
+    rd.ret = 0;
+
+    outl(UKVM_PORT_NETREAD, ukvm_ptr(&rd));
+    cc_barrier();
+
     *n = rd.len;
-
     return rd.ret;
 }
 
 static char mac_str[18];
 char *solo5_net_mac_str(void) {
-	volatile struct ukvm_netinfo info;
+    volatile struct ukvm_netinfo info;
 
-	outl(UKVM_PORT_NETINFO, ukvm_ptr(&info));
+    outl(UKVM_PORT_NETINFO, ukvm_ptr(&info));
+    cc_barrier();
+
     memcpy(mac_str, (void *)&info, 18);
-    
     return mac_str;
 }
-                             
 
 /* ukvm block interface */
 int solo5_blk_write_sync(uint64_t sec, uint8_t *data, int n) {
-	volatile struct ukvm_blkwrite wr;
+    volatile struct ukvm_blkwrite wr;
 
-	wr.sector = sec;
-	wr.data = data;
-	wr.len = n;
-	wr.ret = 0;
+    wr.sector = sec;
+    wr.data = data;
+    wr.len = n;
+    wr.ret = 0;
 
-	outl(UKVM_PORT_BLKWRITE, ukvm_ptr(&wr));
+    outl(UKVM_PORT_BLKWRITE, ukvm_ptr(&wr));
+    cc_barrier();
 
     return wr.ret;
 }
-int solo5_blk_read_sync(uint64_t sec, uint8_t *data, int *n) {
-	volatile struct ukvm_blkread rd;
 
-	rd.sector = sec;
+int solo5_blk_read_sync(uint64_t sec, uint8_t *data, int *n) {
+    volatile struct ukvm_blkread rd;
+
+    rd.sector = sec;
     rd.data = data;
     rd.len = *n;
     rd.ret = 0;
 
-	outl(UKVM_PORT_BLKREAD, ukvm_ptr(&rd));
+    outl(UKVM_PORT_BLKREAD, ukvm_ptr(&rd));
+    cc_barrier();
+
     *n = rd.len;
-    
     return rd.ret;
 }
+
 int solo5_blk_sector_size(void) {
-	volatile struct ukvm_blkinfo info;
-	outl(UKVM_PORT_BLKINFO, ukvm_ptr(&info));
+    volatile struct ukvm_blkinfo info;
+
+    outl(UKVM_PORT_BLKINFO, ukvm_ptr(&info));
+    cc_barrier();
+
     return info.sector_size;
 }
+
 uint64_t solo5_blk_sectors(void) {
-	volatile struct ukvm_blkinfo info;
-	outl(UKVM_PORT_BLKINFO, ukvm_ptr(&info));
+    volatile struct ukvm_blkinfo info;
+
+    outl(UKVM_PORT_BLKINFO, ukvm_ptr(&info));
+    cc_barrier();
+
     return info.num_sectors;
 }
+
 int solo5_blk_rw(void) {
-	volatile struct ukvm_blkinfo info;
-	outl(UKVM_PORT_BLKINFO, ukvm_ptr(&info));
+    volatile struct ukvm_blkinfo info;
+
+    outl(UKVM_PORT_BLKINFO, ukvm_ptr(&info));
+    cc_barrier();
+
     return info.rw;
 }
-

--- a/kernel/ukvm/low_level.c
+++ b/kernel/ukvm/low_level.c
@@ -33,3 +33,5 @@ int low_level_puts(char *buf, int n){
 
     return str.len;
 }
+
+int solo5_console_write(const char *, size_t) __attribute__ ((alias ("low_level_puts")));

--- a/kernel/ukvm/low_level_interrupts.c
+++ b/kernel/ukvm/low_level_interrupts.c
@@ -51,7 +51,7 @@ void low_level_handle_irq(int irq) {
         break;
     default:
         printf("got irq %d at 0x%lx\n", irq, 
-               time_monotonic_ms() );
+               solo5_clock_monotonic() );
         
     }
 

--- a/kernel/ukvm/time.c
+++ b/kernel/ukvm/time.c
@@ -27,9 +27,10 @@ int sleep(uint32_t seconds) {
     t.sec_in = seconds;
     t.nsec_in = 0;
     outl(UKVM_PORT_NANOSLEEP, ukvm_ptr(&t));
+    cc_barrier();
 
-    dprintf("nanosleep = {%d %ld %ld} ms %ld ns %ld\n",
-            t.ret, t.sec_out, t.nsec_out, time_monotonic_ms(), time_monotonic_ns());
+    dprintf("nanosleep = {%d %ld %ld} ns %ld\n",
+            t.ret, t.sec_out, t.nsec_out, pvclock_monotonic());
 
     if ( t.ret < 0 )
         return t.sec_out;
@@ -51,10 +52,7 @@ void time_init(void) {
     pvclock_init();
 }
 
-uint64_t time_monotonic_ms(void) {
-    return pvclock_monotonic() / (NSEC_PER_SEC / MSEC_PER_SEC);
-}
-
-uint64_t time_monotonic_ns(void) {
+uint64_t solo5_clock_monotonic(void)
+{
     return pvclock_monotonic();
 }

--- a/kernel/virtio/kernel.c
+++ b/kernel/virtio/kernel.c
@@ -28,7 +28,7 @@ void kernel_main(uint32_t arg)
     printf("\\__ \\ (   | | (   |  ) | \n");
     printf("____/\\___/ _|\\___/____/  \n");
 
-    if (!gdb) printk("looping for gdb\n");
+    if (!gdb) printf("looping for gdb\n");
     while ( gdb == 0 ); 
 
     /* needs to be very early as it clears the bss */

--- a/kernel/virtio/low_level.c
+++ b/kernel/virtio/low_level.c
@@ -31,3 +31,5 @@ int low_level_puts(char *buf, int n) {
 
     return n;
 }
+
+int solo5_console_write(const char *, size_t) __attribute__ ((alias ("low_level_puts")));

--- a/kernel/virtio/low_level_interrupts.c
+++ b/kernel/virtio/low_level_interrupts.c
@@ -119,7 +119,7 @@ void low_level_handle_irq(int irq) {
         break;
     default:
         printf("got irq %d at 0x%lx\n", irq, 
-               time_monotonic_ms() );
+               solo5_clock_monotonic() );
     }
 
     irq_eoi(irq);

--- a/kernel/virtio/net.c
+++ b/kernel/virtio/net.c
@@ -189,13 +189,13 @@ static void construct_ping(struct pingpkt *p, uint8_t *mac_source) {
 
     if(0) {
         for (i = 0; i < sizeof(struct pingpkt); i++) {
-            printk("%b ", ((uint8_t *)p)[i]);
+            printf("%b ", ((uint8_t *)p)[i]);
             if (i % 8 == 7 )
-                printk("   ");
+                printf("   ");
             if (i % 16 == 15 )
-                printk("\n");
+                printf("\n");
         }
-        printk("\n");
+        printf("\n");
     }
 };
 
@@ -236,8 +236,9 @@ struct pingpkt pings[256]; /* there can actually only be 128
                               virtio_net_hdr taking up so many
                               descriptors */
 
-
-void ping_serve(void) {
+/* XXX Not a "public" API, fix this once we figure out what to do about a
+ * runtime for standalone kernel tests. */
+void solo5_ping_serve(void) {
     uint8_t *pkt = NULL;
     int i;
 

--- a/kernel/virtio/time.c
+++ b/kernel/virtio/time.c
@@ -55,21 +55,8 @@
 static int use_pvclock = 0;
 static volatile uint64_t counts_since_startup = 0;
 
-/* return ms since time_init() */
-uint64_t time_monotonic_ms(void) {
-    if (use_pvclock) {
-        return pvclock_monotonic() / (NSEC_PER_SEC / MSEC_PER_SEC);
-    } else {
-        float sec_since_startup = counts_since_startup /
-            COUNTS_PER_SEC;
-
-        return (uint64_t) (sec_since_startup *
-            MS_PER_SEC);
-    }
-}
-
 /* return ns since time_init() */
-uint64_t time_monotonic_ns(void) {
+uint64_t solo5_clock_monotonic(void) {
     if (use_pvclock) {
         return pvclock_monotonic();
     } else {

--- a/kernel/virtio/virtio.c
+++ b/kernel/virtio/virtio.c
@@ -615,13 +615,15 @@ void virtio_config_network(uint16_t base) {
     guest_features = VIRTIO_NET_F_MAC;
     outl(base + VIRTIO_PCI_GUEST_FEATURES, guest_features);
     
-    printk("Found virtio network device with MAC: ");
+    printf("Found virtio network device with MAC: ");
     for (i = 0; i < 6; i++) {
         virtio_net_mac[i] = inb(base + VIRTIO_PCI_CONFIG_OFF + i);
-        printk("%02x ", virtio_net_mac[i]);
+        printf("%02x ", virtio_net_mac[i]);
     }
-    printk("\n");
-    sprintf(virtio_net_mac_str, "%02x:%02x:%02x:%02x:%02x:%02x",
+    printf("\n");
+    snprintf(virtio_net_mac_str,
+            sizeof virtio_net_mac_str,
+            "%02x:%02x:%02x:%02x:%02x:%02x",
             virtio_net_mac[0],
             virtio_net_mac[1],
             virtio_net_mac[2],

--- a/solo5-kernel-ukvm.opam
+++ b/solo5-kernel-ukvm.opam
@@ -7,3 +7,7 @@ remove: [make "opam-ukvm-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "conf-pkg-config"
 ]
+
+conflicts: [
+  "solo5-kernel-virtio"
+]

--- a/solo5-kernel-ukvm.pc.in
+++ b/solo5-kernel-ukvm.pc.in
@@ -2,10 +2,10 @@ prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
 includedir=${prefix}/include/solo5-kernel-ukvm/include
 libdir=${exec_prefix}/lib/solo5-kernel-ukvm
-linkscript=${libdir}/solo5.lds
+ldflags=!LDFLAGS! -T ${libdir}/solo5.lds ${libdir}/solo5.o
 
 Name: solo5-kernel-ukvm
 Version: 0.1
 Description: Solo5 unikernel base (ukvm target)
 Cflags: !CFLAGS! -I${includedir}
-Libs: ${libdir}/solo5.o
+Libs: !LDLIBS!

--- a/solo5-kernel-virtio.opam
+++ b/solo5-kernel-virtio.opam
@@ -7,3 +7,7 @@ remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "conf-pkg-config"
 ]
+
+conflicts: [
+  "solo5-kernel-ukvm"
+]

--- a/solo5-kernel-virtio.pc.in
+++ b/solo5-kernel-virtio.pc.in
@@ -2,10 +2,10 @@ prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
 includedir=${prefix}/include/solo5-kernel-virtio/include
 libdir=${exec_prefix}/lib/solo5-kernel-virtio
-linkscript=${libdir}/solo5.lds
+ldflags=!LDFLAGS! -T ${libdir}/solo5.lds ${libdir}/solo5.o
 
 Name: solo5-kernel-virtio
 Version: 0.1
 Description: Solo5 unikernel base (virtio target)
 Cflags: !CFLAGS! -I${includedir}
-Libs: ${libdir}/solo5.o
+Libs: !LDLIBS!


### PR DESCRIPTION
Part of djwillia/solo5#19, djwillia/solo5#23. To be applied concurrently with forthcoming PRs to djwillia/mirage, djwillia/mirage-platform.