### PR TITLE
Fix stack alignment for ukvm target

### DIFF
--- a/ukvm/ukvm.c
+++ b/ukvm/ukvm.c
@@ -1094,7 +1094,7 @@ int main(int argc, char **argv)
         .rax = 2,
         .rbx = 2,
         .rflags = 0x2,
-        .rsp = GUEST_SIZE,
+        .rsp = GUEST_SIZE - 8,  // x86_64 ABI requires ((rsp + 8) % 16) == 0
         .rdi = GUEST_SIZE,	// size arg in kernel main
         .rsi = kernel_end,	// kernel_end arg in kernel main
         .rdx = BOOT_ARG_AREA,


### PR DESCRIPTION
The x86_64 ABI mandates that (%rsp + 8) be a multiple of 16 on entry to
a user function. GCC relies on this when using SSE instructions and will
ensure correct alignment is preserved in subsequent function calls.

Per testing, virtio target already appears (possibly not intentionally)
to have the correct stack alignment.