### PR TITLE
Add solo5_poll(), UKVM_PORT_POLL

### DIFF
--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -73,6 +73,7 @@ void interrupts_enable(void);
 void interrupts_disable(void);
 void irq_mask(uint8_t irq);
 void irq_clear(uint8_t irq);
+extern int spldepth;
 
 void sse_enable(void);
 

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -120,6 +120,7 @@ extern uint8_t virtio_net_mac[];
 uint8_t *virtio_net_pkt_get(int *size);  /* get a pointer to recv'd data */
 void virtio_net_pkt_put(void);      /* we're done with recv'd data */
 int virtio_net_xmit_packet(void *data, int len);
+int virtio_net_pkt_poll(void);      /* test if packet(s) are available */
 
 void handle_virtio_interrupt(void);
 

--- a/kernel/solo5.h
+++ b/kernel/solo5.h
@@ -35,6 +35,11 @@ uint64_t solo5_clock_monotonic(void);
 uint64_t solo5_clock_wall(void);
 
 /* Sched related functions */
-void solo5_cpu_block(uint64_t);
+/* solo5_poll(): Block until monotonic time reaches until_nsecs or I/O is
+ * possible, whichever is sooner. Returns 1 if I/O is possible, otherwise 0.
+ *
+ * TODO: Extend this interface to select which I/O events are of interest.
+ */
+int solo5_poll(uint64_t until_nsecs);
 
 #endif

--- a/kernel/ukvm/time.c
+++ b/kernel/ukvm/time.c
@@ -62,13 +62,12 @@ uint64_t solo5_clock_wall(void) {
     return pvclock_monotonic() + cpu_clock_epochoffset();
 }
 
-
-void solo5_cpu_block(uint64_t until_nsecs)
+int solo5_poll(uint64_t until_nsecs)
 {
-    struct ukvm_nanosleep t;
+    struct ukvm_poll t;
 
-    t.sec_in = 0;
-    t.nsec_in = until_nsecs - solo5_clock_monotonic();
-    outl(UKVM_PORT_NANOSLEEP, ukvm_ptr(&t));
+    t.until_nsecs = until_nsecs - solo5_clock_monotonic();
+    outl(UKVM_PORT_POLL, ukvm_ptr(&t));
     cc_barrier();
+    return t.ret;
 }

--- a/kernel/virtio/virtio.c
+++ b/kernel/virtio/virtio.c
@@ -739,7 +739,13 @@ void blk_test(void) {
     
 }
 
-
+int virtio_net_pkt_poll(void)
+{
+    if (recv_next_avail == ((recv_last_used * 2) % recvq.size))
+        return 0;
+    else
+        return 1;
+}
 
 uint8_t *virtio_net_pkt_get(int *size) {
     struct pkt_buffer *buf;

--- a/ukvm/ukvm.h
+++ b/ukvm/ukvm.h
@@ -58,6 +58,8 @@ static inline uint32_t ukvm_ptr(volatile void *p) {
 
 #define UKVM_PORT_DBG_STACK 0x508
 
+#define UKVM_PORT_POLL      0x509
+
 
 /* UKVM_PORT_PUTS */
 struct ukvm_puts {
@@ -144,5 +146,18 @@ struct ukvm_netread {
 	int ret;
 };
 
+/*
+ * UKVM_PORT_POLL: Block until monotonic time reaches until_nsecs or I/O is
+ * possible, whichever is sooner. Returns 1 if I/O is possible, otherwise 0.
+ *
+ * TODO: Extend this interface to select which I/O events are of interest.
+ */
+struct ukvm_poll {
+    /* IN */
+    uint64_t until_nsecs;
+
+    /* OUT */
+    int ret;
+};
 
 #endif


### PR DESCRIPTION
- solo5_poll API to block and wait for I/O. Replaces solo5_cpu_block().
- UKVM_PORT_POLL hypercall to implement solo5_poll() for ukvm target.