### PR TITLE
Handle both IRQ10 and IRQ11 via handle_virtio_interrupt()

### DIFF
--- a/kernel/virtio/low_level_interrupts.c
+++ b/kernel/virtio/low_level_interrupts.c
@@ -111,7 +111,8 @@ void irq_clear(uint8_t irq) {
 }
 void low_level_handle_irq(int irq) {
     switch (irq) {
-    case 0xB:
+    case 0x0a:
+    case 0x0b:
         handle_virtio_interrupt();
         break;
     case 0: /* PIT */

--- a/kernel/virtio/pci.c
+++ b/kernel/virtio/pci.c
@@ -70,6 +70,9 @@ static void virtio_config(uint32_t config_addr) {
     PCI_CONF_READ(uint16_t, &pci.iobar, config_addr, IOBAR);
     PCI_CONF_READ(uint8_t, &pci.interrupt_line, config_addr, INTERRUPT_LINE);
 
+    printf("virtio_config: device_id=%x, interrupt_line=%x\n", pci.device_id,
+            pci.interrupt_line);
+
     /* we only support one net device and one blk device */
     switch(pci.device_id) {
     case PCI_CONF_SUBSYS_NET:


### PR DESCRIPTION
This is a temporary hack to "fix" #32 so that I don't have to keep
carrying a patch in my local tree.