### PR TITLE
Pass command line arguments to the unikernel/application

### DIFF
--- a/kernel/test_hello.c
+++ b/kernel/test_hello.c
@@ -2,13 +2,18 @@
 
 #define UNUSED(x) (void)(x)
 
-int start_kernel(int argc, char **argv)
+int start_kernel(char *cmdline)
 {
-    UNUSED(argc);
-    UNUSED(argv);
-    const char s[] = "Hello, World\n";
+    const char s[] = "Hello, World\nCommand line is: ";
 
     solo5_console_write(s, sizeof s);
+
+    size_t len = 0;
+    char *p = cmdline;
+    while (*p++)
+        len++;
+    solo5_console_write(cmdline, len);
+    solo5_console_write("\n", 1);
 
     return 0;
 }

--- a/kernel/test_ping_serve.c
+++ b/kernel/test_ping_serve.c
@@ -1,13 +1,9 @@
 #include "solo5.h"
 
-#define UNUSED(x) (void)(x)
-
 extern void solo5_ping_serve(void); /* XXX */
 
-int start_kernel(int argc, char  **argv)
+int start_kernel(char *cmdline __attribute__((unused)))
 {
-    UNUSED(argc);
-    UNUSED(argv);
     const char s[] = "Hello, World\n";
 
     solo5_console_write(s, sizeof s);

--- a/ukvm/Makefile
+++ b/ukvm/Makefile
@@ -1,7 +1,7 @@
 all: ukvm
 
 CC=gcc
-CFLAGS=-Wall -Werror
+CFLAGS=-Wall -Werror -std=c99 -O2 -g
 OBJS=ukvm.o gdb-stub.o
 HEADERS=ukvm.h misc.h processor-flags.h
 

--- a/ukvm/ukvm.h
+++ b/ukvm/ukvm.h
@@ -22,16 +22,10 @@
 
 #define GUEST_SIZE      0x20000000 // 512 MBs
 
-#define UKVM_BOOT_ARG_LEN  0x60
-#define UKVM_BOOT_ARG_NUM  32
-struct ukvm_boot_arg {
-    char str[UKVM_BOOT_ARG_LEN];
-};
-struct ukvm_boot_arg_area {
-    /* strings must be on top */
-    struct ukvm_boot_arg strings[UKVM_BOOT_ARG_NUM]; 
-    int argc;
-    char *argv[UKVM_BOOT_ARG_NUM];
+struct ukvm_boot_info {
+    uint64_t mem_size;		/* Memory size in bytes */
+    uint64_t kernel_end;	/* Address of end of kernel */
+    uint64_t cmdline;		/* Address of command line (C string) */
 };
 
 /* 


### PR DESCRIPTION
- Command line arguments are passed as a single string to
  start_kernel(). To be consistent across ukvm/virtio, we pass only the
  arguments and strip any "kernel name" supplied by the bootloader.
- ukvm: Define a ukvm_boot_info structure and pass this to kernel_main()
  instead of individual arguments.
- ukvm: Rationalize memory map and update comments to reflect the
  changes.
- ukvm: Look for '--gdb' before kernel arguments.
- The command line length limits for ukvm (~56k) and virtio (8k) are
  arbitrary, however we warn if the command line is truncated.