### PR TITLE
Rename start_kernel() to solo5_app_main()

### DIFF
--- a/kernel/solo5.h
+++ b/kernel/solo5.h
@@ -6,6 +6,9 @@
 
 /* Solo5 public APIs */
 
+/* Application entry point */
+int solo5_app_main(char *cmdline);
+
 /* Network */
 int solo5_net_write_sync(uint8_t *data, int n);
 int solo5_net_read_sync(uint8_t *data, int *n);

--- a/kernel/test_hello.c
+++ b/kernel/test_hello.c
@@ -1,8 +1,6 @@
 #include "solo5.h"
 
-#define UNUSED(x) (void)(x)
-
-int start_kernel(char *cmdline)
+int solo5_app_main(char *cmdline)
 {
     const char s[] = "Hello, World\nCommand line is: ";
 
@@ -17,4 +15,3 @@ int start_kernel(char *cmdline)
 
     return 0;
 }
-

--- a/kernel/test_ping_serve.c
+++ b/kernel/test_ping_serve.c
@@ -2,7 +2,7 @@
 
 extern void solo5_ping_serve(void); /* XXX */
 
-int start_kernel(char *cmdline __attribute__((unused)))
+int solo5_app_main(char *cmdline __attribute__((unused)))
 {
     const char s[] = "Hello, World\n";
 

--- a/kernel/ukvm/kernel.c
+++ b/kernel/ukvm/kernel.c
@@ -18,19 +18,12 @@
 
 #include "kernel.h"
 
-
-extern int start_kernel(char *cmdline);
-
 static void banner(void) {
     printf("            |      ___|  \n");
     printf("  __|  _ \\  |  _ \\ __ \\  \n");
     printf("\\__ \\ (   | | (   |  ) | \n");
     printf("____/\\___/ _|\\___/____/  \n");
 }
-
-/* args are: 
-   uint64_t size, uint64_t kernel_end, ...
-*/
 
 void kernel_main(struct ukvm_boot_info *bi)
 {
@@ -47,8 +40,8 @@ void kernel_main(struct ukvm_boot_info *bi)
     sse_enable();
     time_init();
 
-    int ret = start_kernel((char *)bi->cmdline);
-    printf("start_kernel returned with %d\n", ret);
+    int ret = solo5_app_main((char *)bi->cmdline);
+    printf("solo5_app_main() returned with %d\n", ret);
 
     printf("Kernel done. \nGoodbye!\n");
     kernel_hang();

--- a/kernel/virtio/kernel.c
+++ b/kernel/virtio/kernel.c
@@ -18,7 +18,6 @@
 
 #include "kernel.h"
 
-extern int start_kernel(char *cmdline);
 extern void bounce_stack(uint64_t stack_start, void (*tramp)(void));
 static void kernel_main2(void) __attribute__((noreturn));
 
@@ -87,8 +86,8 @@ static void kernel_main2(void)
 
     interrupts_enable();
 
-    int ret = start_kernel(cmdline);
-    printf("start_kernel returned with %d\n", ret);
+    int ret = solo5_app_main(cmdline);
+    printf("solo5_app_main() returned with %d\n", ret);
 
     printf("Kernel done. \nGoodbye!\n");
     kernel_hang();


### PR DESCRIPTION
Better naming for the application entrypoint. Also, move prototype to
solo5.h to ensure consistency.