### PR TITLE
use -print-file-name=include instead of -print-search-dirs and sed magic

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -24,8 +24,8 @@ OBJCOPY?=objcopy
 #   - Standard C headers required by C89/C99. -nostdinc removes access to these
 #     so get it back by asking GCC for its installation directory.
 #   - The static libgcc.a (compiler runtime) installed by the host GCC.
-GCC_INSTALL_DIR=$(shell LANG=C $(CC) -print-search-dirs | sed -n -e 's/install: \(.*\)/\1/p')
-MD_CFLAGS=-nostdinc -isystem $(GCC_INSTALL_DIR)include \
+GCC_INCLUDE_DIR=$(shell $(CC) -print-file-name=include)
+MD_CFLAGS=-nostdinc -isystem $(GCC_INCLUDE_DIR) \
 	  -ffreestanding -mno-red-zone -mno-3dnow
 LDFLAGS=-nostdlib -static --nmagic
 LDLIBS=$(shell $(CC) -print-libgcc-file-name)


### PR DESCRIPTION
this is (imho) less brittle...