### PR TITLE
CC is cc, not gcc

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -16,7 +16,7 @@
 # PERFORMANCE OF THIS SOFTWARE.
 
 AS?=as
-CC?=gcc
+CC?=cc
 LD?=ld
 OBJCOPY?=objcopy
 # Ensure no host headers or libraries are used when building, with the

--- a/ukvm/Makefile
+++ b/ukvm/Makefile
@@ -1,6 +1,6 @@
 all: ukvm
 
-CC?=gcc
+CC?=cc
 CFLAGS=-Wall -Werror -std=c99 -O2 -g
 OBJS=ukvm.o gdb-stub.o
 HEADERS=ukvm.h misc.h processor-flags.h


### PR DESCRIPTION
at least on all the machines I have access to, even on ubuntu linux, you get a cc binary... cc is also common on MacOSX and FreeBSD for the C compiler... (where there might be no gcc installed)...