### PR TITLE
Revert changes to linker scripts / --nmagic

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -27,7 +27,7 @@ OBJCOPY?=objcopy
 GCC_INCLUDE_DIR=$(shell $(CC) -print-file-name=include)
 MD_CFLAGS=-nostdinc -isystem $(GCC_INCLUDE_DIR) \
 	  -ffreestanding -mno-red-zone -mno-3dnow
-LDFLAGS=-nostdlib -static --nmagic
+LDFLAGS=-nostdlib -z max-page-size=0x1000 -static
 LDLIBS=$(shell $(CC) -print-libgcc-file-name)
 # Platform-independent CFLAGS
 CFLAGS=$(MD_CFLAGS) -std=gnu99 -Wall -Wextra -Werror -O2 -g

--- a/kernel/ukvm/solo5.lds
+++ b/kernel/ukvm/solo5.lds
@@ -1,39 +1,36 @@
 ENTRY(kernel_main)
 
 SECTIONS {
+
+    /* kernel at 1MB */
     . = 0x100000;
-    _begin = .;
 
-    .bootstrap :
-    {
-        *(.bootstrap)
-    }
+	.text BLOCK(4K) : ALIGN(4K)
+	{
+		*(.text)
+	}
 
-    .text ALIGN(0x1000):
-    {
-        *(.text)
-	*(.text.*)
-    }
+	/* Read-only data. */
+	.rodata BLOCK(4K) : ALIGN(4K)
+	{
+		*(.rodata)
+	}
 
-    .rodata ALIGN(0x1000):
-    {
-        *(.rodata)
-	*(.rodata.*)
-    }
+	/* Read-write data (initialized) */
+	.data BLOCK(4K) : ALIGN(4K)
+	{
+		*(.data)
+	}
 
-    .data ALIGN(0x1000):
-    {
-        *(.data)
-	*(.data.*)
-    }
-    _edata = .;
+	/* Read-write data (uninitialized) */
+    bss_start = .;
+	.bss BLOCK(4K) : ALIGN(4K)
+	{
+		*(COMMON)
+		*(.bss)
+	}
+    bss_end = .;
 
-    .bss ALIGN(0x1000):
-    {
-        *(.bss)
-	*(.bss.*)
-        *(COMMON)
-    }
-    _ebss = .;
-    _end = .;
+	/* The compiler may produce other sections, by default it will put them in
+	   a segment with the same name. Simply add stuff here as needed. */
 }

--- a/kernel/virtio/solo5.lds
+++ b/kernel/virtio/solo5.lds
@@ -1,5 +1,3 @@
-OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
-OUTPUT_ARCH(i386:x86-64)
 ENTRY(_start)
 
 SECTIONS {

--- a/kernel/virtio/solo5.lds
+++ b/kernel/virtio/solo5.lds
@@ -4,37 +4,35 @@ ENTRY(_start)
 
 SECTIONS {
     . = 0x100000;
-    _begin = .;
-
+    
     .bootstrap :
     {
         *(.bootstrap)
     }
 
-    .text ALIGN(0x1000):
+    .text BLOCK(4K) : ALIGN(4K)
     {
         *(.text)
-	*(.text.*)
     }
 
-    .rodata ALIGN(0x1000):
+    /* Read-only data. */
+    .rodata BLOCK(4K) : ALIGN(4K)
     {
         *(.rodata)
-	*(.rodata.*)
     }
 
-    .data ALIGN(0x1000):
+    /* Read-write data (initialized) */
+    .data BLOCK(4K) : ALIGN(4K)
     {
         *(.data)
-	*(.data.*)
     }
     _edata = .;
 
-    .bss ALIGN(0x1000):
+    /* Read-write data (uninitialized) */
+    .bss BLOCK(4K) : ALIGN(4K)
     {
-        *(.bss)
-	*(.bss.*)
         *(COMMON)
+        *(.bss)
     }
     _ebss = .;
     _end = .;


### PR DESCRIPTION
--nmagic has side effects which a) break ukvm and b) we don't want in general (results in a single RWX phdr for the entire kernel). Revert those changes, and introduce a possible workaround for FreeBSD.