### PR TITLE
modularize ukvm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ kvm: test.iso disk.img
 		 -drive file=disk.img,if=virtio 
 
 ukvm: ukvm_target disk.img
-	sudo ukvm/ukvm disk.img tap100 kernel/test_hello.ukvm
+	sudo ukvm/ukvm --disk=disk.img --net=tap100 kernel/test_hello.ukvm
 
 gdb: ukvm_target disk.img
-	sudo time -f"%E elapsed" ukvm/ukvm kernel/test_hello.ukvm disk.img tap100 --gdb
+	sudo time -f"%E elapsed" ukvm/ukvm --disk=disk.img --net=tap100 --gdb kernel/test_hello.ukvm 
 
 clean:
 	@echo -n cleaning...

--- a/ukvm/Makefile
+++ b/ukvm/Makefile
@@ -1,12 +1,15 @@
 all: ukvm
 
+include Makefile.ukvm
+
 CC?=cc
-CFLAGS=-Wall -Werror -std=c99 -O2 -g
-OBJS=ukvm.o gdb-stub.o
+UKVM_FLAGS=-D__UKVM_HOST__ $(UKVM_MODULE_FLAGS)
+CFLAGS=-Wall -Werror -std=c99 -O2 -g $(UKVM_FLAGS)
+OBJS=ukvm.o $(UKVM_MODULE_OBJS)
 HEADERS=ukvm.h misc.h processor-flags.h
 
 ukvm: $(OBJS) $(HEADERS)
-	$(CC) -o $@ $(OBJS) -lpthread -lrt
+	$(CC) -o $@ $(CFLAGS) $(OBJS) -lpthread -lrt
 
 clean:
 	rm -f ukvm $(OBJS)

--- a/ukvm/Makefile.ukvm
+++ b/ukvm/Makefile.ukvm
@@ -1,0 +1,10 @@
+UKVM_MODULE_OBJS= \
+ukvm-blk.o \
+ukvm-gdb.o \
+ukvm-net.o \
+
+UKVM_MODULE_FLAGS= \
+-DUKVM_MODULE_BLK \
+-DUKVM_MODULE_GDB \
+-DUKVM_MODULE_NET \
+

--- a/ukvm/ukvm-blk.c
+++ b/ukvm/ukvm-blk.c
@@ -86,9 +86,9 @@ static int handle_exit(struct kvm_run *run, int vcpufd, uint8_t *mem)
 
 static int handle_cmdarg(char *cmdarg)
 {
-    if (strncmp("disk=", cmdarg, 5))
+    if (strncmp("--disk=", cmdarg, 7))
         return -1;
-    diskfile = cmdarg + 5;
+    diskfile = cmdarg + 7;
 
     return 0;
 }
@@ -121,7 +121,7 @@ static int get_fd(void)
 
 static char *usage(void)
 {
-    return "blk=<disk.img>";
+    return "--disk=IMAGE (file exposed to the unikernel as a raw block device)";
 }
 
 struct ukvm_module ukvm_blk = {

--- a/ukvm/ukvm-blk.c
+++ b/ukvm/ukvm-blk.c
@@ -1,0 +1,134 @@
+#include <err.h>
+#include <fcntl.h>
+#include <linux/kvm.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "ukvm.h"
+#include "ukvm_modules.h"
+
+static struct ukvm_blkinfo blkinfo;
+static char *diskfile;
+static int diskfd;
+
+static void ukvm_port_blkinfo(uint8_t *mem, void *data)
+{
+    uint32_t mem_off = *(uint32_t *) data;
+    struct ukvm_blkinfo *info = (struct ukvm_blkinfo *) (mem + mem_off);
+
+    info->sector_size = blkinfo.sector_size;
+    info->num_sectors = blkinfo.num_sectors;
+    info->rw = blkinfo.rw;
+}
+
+static void ukvm_port_blkwrite(uint8_t *mem, void *data)
+{
+    uint32_t mem_off = *(uint32_t *) data;
+    struct ukvm_blkwrite *wr = (struct ukvm_blkwrite *) (mem + mem_off);
+    int ret;
+
+    wr->ret = -1;
+    if (wr->sector < blkinfo.num_sectors) {
+        lseek(diskfd, blkinfo.sector_size * wr->sector, SEEK_SET);
+        ret = write(diskfd, mem + (uint64_t) wr->data, wr->len);
+        assert(ret == wr->len);
+        wr->ret = 0;
+    }
+}
+
+static void ukvm_port_blkread(uint8_t *mem, void *data)
+{
+    uint32_t mem_off = *(uint32_t *) data;
+    struct ukvm_blkread *rd = (struct ukvm_blkread *) (mem + mem_off);
+    int ret;
+
+    rd->ret = -1;
+    if (rd->sector < blkinfo.num_sectors) {
+        lseek(diskfd, blkinfo.sector_size * rd->sector, SEEK_SET);
+        ret = read(diskfd, mem + (uint64_t) rd->data, rd->len);
+        assert(ret == rd->len);
+        rd->ret = 0;
+    }
+}
+
+static int handle_exit(struct kvm_run *run, int vcpufd, uint8_t *mem)
+{
+    uint8_t *data;
+
+    if (run->exit_reason != KVM_EXIT_IO)
+        return -1;
+
+    if (run->io.direction != KVM_EXIT_IO_OUT)
+        return -1;
+
+    data = (uint8_t *)run + run->io.data_offset;
+
+    switch (run->io.port) {
+    case UKVM_PORT_BLKINFO:
+        ukvm_port_blkinfo(mem, data);
+        break;
+    case UKVM_PORT_BLKWRITE:
+        ukvm_port_blkwrite(mem, data);
+        break;
+    case UKVM_PORT_BLKREAD:
+        ukvm_port_blkread(mem, data);
+        break;
+    default:
+        return -1;
+    }
+
+    return 0;
+}
+
+static int handle_cmdarg(char *cmdarg)
+{
+    if (strncmp("disk=", cmdarg, 5))
+        return -1;
+    diskfile = cmdarg + 5;
+
+    return 0;
+}
+
+static int setup(int vcpufd, uint8_t *mem)
+{
+    if (diskfile == NULL)
+        return -1;
+
+    /* set up virtual disk */
+    diskfd = open(diskfile, O_RDWR);
+    if (diskfd == -1)
+        err(1, "couldn't open disk %s", diskfile);
+
+    blkinfo.sector_size = 512;
+    blkinfo.num_sectors = lseek(diskfd, 0, SEEK_END) / 512;
+    blkinfo.rw = 1;
+
+    printf("Providing disk: %ld sectors @ %d = %ld bytes\n",
+           blkinfo.num_sectors, blkinfo.sector_size,
+           blkinfo.num_sectors * blkinfo.sector_size);
+
+    return 0;
+}
+
+static int get_fd(void)
+{
+    return 0; /* no fd for poll to sleep on (synchronous) */
+}
+
+static char *usage(void)
+{
+    return "blk=<disk.img>";
+}
+
+struct ukvm_module ukvm_blk = {
+    .get_fd = get_fd,
+    .handle_exit = handle_exit,
+    .handle_cmdarg = handle_cmdarg,
+    .setup = setup,
+    .usage = usage
+};
+

--- a/ukvm/ukvm-gdb.c
+++ b/ukvm/ukvm-gdb.c
@@ -673,7 +673,7 @@ static int get_fd(void)
 
 static char *usage(void)
 {
-    return "--gdb";
+    return "--gdb (optional flag for running in a gdb debug session)";
 }
 
 struct ukvm_module ukvm_gdb = {

--- a/ukvm/ukvm-net.c
+++ b/ukvm/ukvm-net.c
@@ -154,9 +154,9 @@ static int handle_exit(struct kvm_run *run, int vcpufd, uint8_t *mem)
 
 static int handle_cmdarg(char *cmdarg)
 {
-    if (strncmp("net=", cmdarg, 4))
+    if (strncmp("--net=", cmdarg, 6))
         return -1;
-    netiface = cmdarg + 4;
+    netiface = cmdarg + 6;
     return 0;
 }
 
@@ -206,7 +206,7 @@ static int get_fd(void)
 
 static char *usage(void)
 {
-    return "net=<tap100>";
+    return "--net=TAP (host tap device for guest network interface)";
 }
 
 struct ukvm_module ukvm_net = {

--- a/ukvm/ukvm-net.c
+++ b/ukvm/ukvm-net.c
@@ -1,0 +1,218 @@
+#include <linux/kvm.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include <sys/select.h>
+
+/* for net */
+#include <sys/socket.h>
+#include <linux/if_packet.h>
+#include <net/ethernet.h>
+#include <net/if.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <err.h>
+
+#include "ukvm.h"
+#include "ukvm_modules.h"
+
+static char *netiface;
+static int netfd;
+static struct ukvm_netinfo netinfo;
+
+/*
+ * Create or reuse a TUN or TAP device named 'dev'.
+ *
+ * Copied from kernel docs: Documentation/networking/tuntap.txt
+ */
+static int tun_alloc(char *dev, int flags)
+{
+    struct ifreq ifr;
+    int fd, err;
+    char *clonedev = "/dev/net/tun";
+
+    /* Arguments taken by the function:
+     *
+     * char *dev: the name of an interface (or '\0'). MUST have enough
+     *   space to hold the interface name if '\0' is passed
+     * int flags: interface flags (eg, IFF_TUN etc.)
+     */
+
+    /* open the clone device */
+    fd = open(clonedev, O_RDWR);
+    if (fd < 0)
+        return fd;
+
+    /* preparation of the struct ifr, of type "struct ifreq" */
+    memset(&ifr, 0, sizeof(ifr));
+
+    ifr.ifr_flags = flags;	/* IFF_TUN or IFF_TAP, plus maybe IFF_NO_PI */
+
+    if (*dev) {
+        /* if a device name was specified, put it in the structure; otherwise,
+         * the kernel will try to allocate the "next" device of the
+         * specified type
+         */
+        strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+    }
+
+    /* try to create the device */
+    err = ioctl(fd, TUNSETIFF, (void *) &ifr);
+    if (err < 0) {
+        close(fd);
+        return err;
+    }
+
+    /* if the operation was successful, write back the name of the
+     * interface to the variable "dev", so the caller can know
+     * it. Note that the caller MUST reserve space in *dev (see calling
+     * code below)
+     */
+    strcpy(dev, ifr.ifr_name);
+
+    /* this is the special file descriptor that the caller will use to talk
+     * with the virtual interface
+     */
+    return fd;
+}
+
+static void ukvm_port_netinfo(uint8_t *mem, void *data)
+{
+    uint32_t mem_off = *(uint32_t *) data;
+    struct ukvm_netinfo *info = (struct ukvm_netinfo *) (mem + mem_off);
+
+    memcpy(info->mac_str, netinfo.mac_str, sizeof(netinfo.mac_str));
+}
+
+static void ukvm_port_netwrite(uint8_t *mem, void *data)
+{
+    uint32_t mem_off = *(uint32_t *) data;
+    struct ukvm_netwrite *wr = (struct ukvm_netwrite *) (mem + mem_off);
+    int ret;
+
+    wr->ret = 0;
+    ret = write(netfd, mem + (uint64_t) wr->data, wr->len);
+    assert(wr->len == ret);
+}
+
+static void ukvm_port_netread(uint8_t *mem, void *data)
+{
+    uint32_t mem_off = *(uint32_t *) data;
+    struct ukvm_netread *rd = (struct ukvm_netread *) (mem + mem_off);
+    struct timeval zero;
+    fd_set netset;
+    int ret;
+
+    FD_ZERO(&netset);
+    FD_SET(netfd, &netset);
+    zero.tv_sec = 0;
+    zero.tv_usec = 0;
+    ret = select(netfd + 1, &netset, NULL, NULL, &zero);
+    if (ret <= 0) {
+        rd->ret = -1;
+        return;
+    }
+
+    rd->len = read(netfd, mem + (uint64_t) rd->data, rd->len);
+    rd->ret = 0;
+}
+
+static int handle_exit(struct kvm_run *run, int vcpufd, uint8_t *mem)
+{
+    uint8_t *data;
+
+    if (run->exit_reason != KVM_EXIT_IO)
+        return -1;
+
+    if (run->io.direction != KVM_EXIT_IO_OUT)
+        return -1;
+
+    data = (uint8_t *)run + run->io.data_offset;
+
+    switch (run->io.port) {
+    case UKVM_PORT_NETINFO:
+        ukvm_port_netinfo(mem, data);
+        break;
+    case UKVM_PORT_NETWRITE:
+        ukvm_port_netwrite(mem, data);
+        break;
+    case UKVM_PORT_NETREAD:
+        ukvm_port_netread(mem, data);
+        break;
+    default:
+        return -1;
+    }
+
+    return 0;
+}
+
+static int handle_cmdarg(char *cmdarg)
+{
+    if (strncmp("net=", cmdarg, 4))
+        return -1;
+    netiface = cmdarg + 4;
+    return 0;
+}
+
+static int setup(int vcpufd, uint8_t *mem)
+{
+    char tun_name[IFNAMSIZ];
+
+    if (netiface == NULL)
+        return -1;
+
+    /* set up virtual network */
+    strcpy(tun_name, netiface);
+    netfd = tun_alloc(tun_name, IFF_TAP | IFF_NO_PI);	/* TAP interface */
+    if (netfd < 0) {
+        perror("Allocating interface");
+        exit(1);
+    }
+    /* generate a random, locally-administered and unicast MAC address */
+    int rfd = open("/dev/urandom", O_RDONLY);
+
+    if (rfd == -1)
+        err(1, "Could not open /dev/urandom");
+
+    uint8_t guest_mac[6];
+    int ret;
+
+    ret = read(rfd, guest_mac, sizeof(guest_mac));
+    assert(ret == sizeof(guest_mac));
+    close(rfd);
+    guest_mac[0] &= 0xfe;
+    guest_mac[0] |= 0x02;
+    snprintf(netinfo.mac_str, sizeof(netinfo.mac_str),
+            "%02x:%02x:%02x:%02x:%02x:%02x",
+            guest_mac[0], guest_mac[1], guest_mac[2],
+            guest_mac[3], guest_mac[4], guest_mac[5]);
+
+    printf("Providing network: %s, guest address %s\n", tun_name,
+            netinfo.mac_str);
+
+    return 0;
+}
+
+static int get_fd(void)
+{
+    return netfd;
+}
+
+static char *usage(void)
+{
+    return "net=<tap100>";
+}
+
+struct ukvm_module ukvm_net = {
+    .get_fd = get_fd,
+    .handle_exit = handle_exit,
+    .handle_cmdarg = handle_cmdarg,
+    .setup = setup,
+    .usage = usage
+};

--- a/ukvm/ukvm-net.c
+++ b/ukvm/ukvm-net.c
@@ -11,9 +11,6 @@
 
 /* for net */
 #include <sys/socket.h>
-#include <linux/if_packet.h>
-#include <net/ethernet.h>
-#include <net/if.h>
 #include <linux/if.h>
 #include <linux/if_tun.h>
 #include <fcntl.h>

--- a/ukvm/ukvm.c
+++ b/ukvm/ukvm.c
@@ -779,6 +779,11 @@ int main(int argc, char **argv)
         }
     } while (matched);
 
+    if (*argv[0] == '-') {
+        printf("Invalid option: %s\n", *argv);
+        return 1;
+    }
+
     elffile = *argv;
     argc--;
     argv++;

--- a/ukvm/ukvm.c
+++ b/ukvm/ukvm.c
@@ -41,24 +41,26 @@
 #include <assert.h>
 #include <signal.h>
 #include <pthread.h>
-
-/* for net */
-#include <sys/socket.h>
-#include <linux/if_packet.h>
-#include <net/ethernet.h>
-#include <net/if.h>
-#include <linux/if_tun.h>
 #include <poll.h>
-
 
 #include "processor-flags.h"
 #include "../kernel/interrupts.h"
 #include "ukvm.h"
+#include "ukvm_modules.h"
 #include "misc.h"
 
-
-struct ukvm_blkinfo blkinfo;
-struct ukvm_netinfo netinfo;
+struct ukvm_module *modules[] = {
+#ifdef UKVM_MODULE_BLK
+    &ukvm_blk,
+#endif
+#ifdef UKVM_MODULE_NET
+    &ukvm_net,
+#endif
+#ifdef UKVM_MODULE_GDB
+    &ukvm_gdb,
+#endif
+};
+#define NUM_MODULES (sizeof(modules) / sizeof(struct ukvm_module *))
 
 /*
  * Memory map:
@@ -147,10 +149,6 @@ struct _kvm_segment {
 #define KVM_32BIT_MAX_MEM_SIZE  (1ULL << 32)
 #define KVM_32BIT_GAP_SIZE    (768 << 20)
 #define KVM_32BIT_GAP_START    (KVM_32BIT_MAX_MEM_SIZE - KVM_32BIT_GAP_SIZE)
-
-void gdb_stub_start(int vcpufd);
-void gdb_handle_exception(int vcpufd, int sig);
-int gdb_is_pc_breakpointing(long addr);
 
 void setup_boot_info(uint8_t *mem,
                     uint64_t size,
@@ -577,93 +575,6 @@ void ukvm_port_nanosleep(uint8_t *mem, void *data, struct kvm_run *run)
     }
 }
 
-
-void ukvm_port_blkinfo(uint8_t *mem, void *data)
-{
-    uint32_t mem_off = *(uint32_t *) data;
-    struct ukvm_blkinfo *info = (struct ukvm_blkinfo *) (mem + mem_off);
-
-    info->sector_size = blkinfo.sector_size;
-    info->num_sectors = blkinfo.num_sectors;
-    info->rw = blkinfo.rw;
-}
-
-
-void ukvm_port_blkwrite(uint8_t *mem, void *data, int diskfd)
-{
-    uint32_t mem_off = *(uint32_t *) data;
-    struct ukvm_blkwrite *wr = (struct ukvm_blkwrite *) (mem + mem_off);
-    int ret;
-
-    wr->ret = -1;
-    if (wr->sector < blkinfo.num_sectors) {
-        lseek(diskfd, blkinfo.sector_size * wr->sector, SEEK_SET);
-        ret = write(diskfd, mem + (uint64_t) wr->data, wr->len);
-        assert(ret == wr->len);
-        wr->ret = 0;
-    }
-}
-
-
-void ukvm_port_blkread(uint8_t *mem, void *data, int diskfd)
-{
-    uint32_t mem_off = *(uint32_t *) data;
-    struct ukvm_blkread *rd = (struct ukvm_blkread *) (mem + mem_off);
-    int ret;
-
-    rd->ret = -1;
-    if (rd->sector < blkinfo.num_sectors) {
-        lseek(diskfd, blkinfo.sector_size * rd->sector, SEEK_SET);
-        ret = read(diskfd, mem + (uint64_t) rd->data, rd->len);
-        assert(ret == rd->len);
-        rd->ret = 0;
-    }
-}
-
-
-void ukvm_port_netinfo(uint8_t *mem, void *data)
-{
-    uint32_t mem_off = *(uint32_t *) data;
-    struct ukvm_netinfo *info = (struct ukvm_netinfo *) (mem + mem_off);
-
-    memcpy(info->mac_str, netinfo.mac_str, sizeof(netinfo.mac_str));
-}
-
-void ukvm_port_netwrite(uint8_t *mem, void *data, int netfd)
-{
-    uint32_t mem_off = *(uint32_t *) data;
-    struct ukvm_netwrite *wr = (struct ukvm_netwrite *) (mem + mem_off);
-    int ret;
-
-    wr->ret = 0;
-    ret = write(netfd, mem + (uint64_t) wr->data, wr->len);
-    assert(wr->len == ret);
-}
-
-
-void ukvm_port_netread(uint8_t *mem, void *data, int netfd)
-{
-    uint32_t mem_off = *(uint32_t *) data;
-    struct ukvm_netread *rd = (struct ukvm_netread *) (mem + mem_off);
-    struct timeval zero;
-    fd_set netset;
-    int ret;
-
-    FD_ZERO(&netset);
-    FD_SET(netfd, &netset);
-    zero.tv_sec = 0;
-    zero.tv_usec = 0;
-    ret = select(netfd + 1, &netset, NULL, NULL, &zero);
-    if (ret <= 0) {
-        rd->ret = -1;
-        return;
-    }
-
-    rd->len = read(netfd, mem + (uint64_t) rd->data, rd->len);
-    rd->ret = 0;
-}
-
-
 void ukvm_port_dbg_stack(uint8_t *mem, int vcpufd)
 {
     struct kvm_regs regs;
@@ -685,47 +596,64 @@ void ukvm_port_dbg_stack(uint8_t *mem, int vcpufd)
     }
 }
 
-void ukvm_port_poll(uint8_t *mem, void *data, int netfd)
+void ukvm_port_poll(uint8_t *mem, void *data)
 {
     uint32_t arg_addr = *(uint32_t *) data;
     struct ukvm_poll *t = (struct ukvm_poll *) (mem + arg_addr);
     struct timespec ts;
-    struct pollfd fds = { .fd = netfd, .events = POLLIN };
-    int rc;
+    int rc, i, num_fds = 0;
+    struct pollfd fds[NUM_MODULES];  /* we only support at most one
+                                      * instance per module for now
+                                      */
+
+    for (i = 0; i < NUM_MODULES; i++) {
+        int fd = modules[i]->get_fd();
+
+        if (fd) {
+            fds[num_fds].fd = fd;
+            fds[num_fds].events = POLLIN;
+            num_fds += 1;
+        }
+    }
+
 
     ts.tv_sec = t->until_nsecs / 1000000000ULL;
     ts.tv_nsec = t->until_nsecs % 1000000000ULL;
 
     /*
-     * Guest execution is blocked during the ppoll() call, note that interrupts
-     * will not be injected.
+     * Guest execution is blocked during the ppoll() call, note that
+     * interrupts will not be injected.
      */
-    rc = ppoll(&fds, 1, &ts, NULL);
+    rc = ppoll(fds, num_fds, &ts, NULL);
     assert(rc >= 0);
     t->ret = rc;
 }
 
-static int vcpu_loop(struct kvm_run *run, int vcpufd, uint8_t *mem,
-                     int diskfd, int netfd)
+static int vcpu_loop(struct kvm_run *run, int vcpufd, uint8_t *mem)
 {
     int ret;
 
     /* Repeatedly run code and handle VM exits. */
     while (1) {
+        int i, handled = 0;
+
         ret = ioctl(vcpufd, KVM_RUN, NULL);
         if (ret < 0 &&
                 (errno != EINTR && errno != EAGAIN)) {
             err(1, "KVM_RUN failed");
         }
 
-        switch (run->exit_reason) {
-        case KVM_EXIT_DEBUG: {
-            struct kvm_debug_exit_arch *arch_info = &run->debug.arch;
-
-            if (gdb_is_pc_breakpointing(arch_info->pc))
-                gdb_handle_exception(vcpufd, 1);
-            break;
+        for (i = 0; i < NUM_MODULES; i++) {
+            if (!modules[i]->handle_exit(run, vcpufd, mem)) {
+                handled = 1;
+                break;
+            }
         }
+
+        if (handled)
+            continue;
+
+        switch (run->exit_reason) {
         case KVM_EXIT_HLT: {
             puts("KVM_EXIT_HLT");
             /* get_and_dump_sregs(vcpufd); */
@@ -743,29 +671,11 @@ static int vcpu_loop(struct kvm_run *run, int vcpufd, uint8_t *mem,
             case UKVM_PORT_NANOSLEEP:
                 ukvm_port_nanosleep(mem, data, run);
                 break;
-            case UKVM_PORT_BLKINFO:
-                ukvm_port_blkinfo(mem, data);
-                break;
-            case UKVM_PORT_BLKWRITE:
-                ukvm_port_blkwrite(mem, data, diskfd);
-                break;
-            case UKVM_PORT_BLKREAD:
-                ukvm_port_blkread(mem, data, diskfd);
-                break;
-            case UKVM_PORT_NETINFO:
-                ukvm_port_netinfo(mem, data);
-                break;
-            case UKVM_PORT_NETWRITE:
-                ukvm_port_netwrite(mem, data, netfd);
-                break;
-            case UKVM_PORT_NETREAD:
-                ukvm_port_netread(mem, data, netfd);
-                break;
             case UKVM_PORT_DBG_STACK:
                 ukvm_port_dbg_stack(mem, vcpufd);
                 break;
             case UKVM_PORT_POLL:
-                ukvm_port_poll(mem, data, netfd);
+                ukvm_port_poll(mem, data);
                 break;
             default:
                 errx(1, "unhandled KVM_EXIT_IO (%x)", run->io.port);
@@ -800,61 +710,15 @@ static int vcpu_loop(struct kvm_run *run, int vcpufd, uint8_t *mem,
     return 0; /* XXX Refactor return code paths in the above code */
 }
 
-
-/*
- * Create or reuse a TUN or TAP device named 'dev'.
- *
- * Copied from kernel docs: Documentation/networking/tuntap.txt
- */
-int tun_alloc(char *dev, int flags)
+int setup_modules(int vcpufd, uint8_t *mem)
 {
-    struct ifreq ifr;
-    int fd, err;
-    char *clonedev = "/dev/net/tun";
+    int i;
 
-    /* Arguments taken by the function:
-     *
-     * char *dev: the name of an interface (or '\0'). MUST have enough
-     *   space to hold the interface name if '\0' is passed
-     * int flags: interface flags (eg, IFF_TUN etc.)
-     */
+    for (i = 0; i < NUM_MODULES; i++)
+        if (modules[i]->setup(vcpufd, mem))
+            return -1;
 
-    /* open the clone device */
-    fd = open(clonedev, O_RDWR);
-    if (fd < 0)
-        return fd;
-
-    /* preparation of the struct ifr, of type "struct ifreq" */
-    memset(&ifr, 0, sizeof(ifr));
-
-    ifr.ifr_flags = flags;	/* IFF_TUN or IFF_TAP, plus maybe IFF_NO_PI */
-
-    if (*dev) {
-        /* if a device name was specified, put it in the structure; otherwise,
-         * the kernel will try to allocate the "next" device of the
-         * specified type
-         */
-        strncpy(ifr.ifr_name, dev, IFNAMSIZ);
-    }
-
-    /* try to create the device */
-    err = ioctl(fd, TUNSETIFF, (void *) &ifr);
-    if (err < 0) {
-        close(fd);
-        return err;
-    }
-
-    /* if the operation was successful, write back the name of the
-     * interface to the variable "dev", so the caller can know
-     * it. Note that the caller MUST reserve space in *dev (see calling
-     * code below)
-     */
-    strcpy(dev, ifr.ifr_name);
-
-    /* this is the special file descriptor that the caller will use to talk
-     * with the virtual interface
-     */
-    return fd;
+    return 0;
 }
 
 void sig_handler(int signo)
@@ -863,78 +727,48 @@ void sig_handler(int signo)
     exit(0);
 }
 
-uint8_t *mem;
-
 int main(int argc, char **argv)
 {
-    int kvm, vmfd, vcpufd, diskfd, netfd, ret;
+    int kvm, vmfd, vcpufd, ret;
+    uint8_t *mem;
     struct kvm_run *run;
     size_t mmap_size;
     uint64_t elf_entry;
     uint64_t kernel_end;
-    char tun_name[IFNAMSIZ];
-    int use_gdb = 0;
+    int num_args = 0;
+    char *first_arg;
+    int i;
 
-    /* TODO: Replace this with a proper argument parser */
-    if (argc < 4)
-        err(1, "usage: ukvm <disk.img> <net_iface> <elf> [--gdb] [args]");
+    if (argc < 2) {
+        int m;
 
-    const char *diskfile = argv[1];
-    const char *netiface = argv[2];
-    const char *elffile = argv[3];
+        printf("usage: ukvm <elf> [args] --");
+        for (m = 0; m < NUM_MODULES; m++)
+            printf(" %s", modules[m]->usage());
+        printf("\n");
+        return 1;
+    }
 
-    argc -= 4;
-    argv += 4;
-    if (argc >= 1) {
-        use_gdb = strcmp(argv[0], "--gdb") == 0;
-        if (use_gdb) {
-            argc--;
-            argv++;
-        }
+    const char *elffile = argv[1];
+
+    first_arg = argv[2];
+    for (i = 2; i < argc; i++) {
+        if (!strcmp("--", argv[i]))
+            break;
+        num_args++;
+    }
+
+    printf("Found %d args (%d left)\n", num_args, argc - num_args - 3);
+    for (i = num_args + 3; i < argc; i++) {
+        int j;
+
+        for (j = 0; j < NUM_MODULES; j++)
+            if (!modules[j]->handle_cmdarg(argv[i]))
+                break;
     }
 
     if (signal(SIGINT, sig_handler) == SIG_ERR)
         err(1, "Can not catch SIGINT");
-
-    /* set up virtual disk */
-    diskfd = open(diskfile, O_RDWR);
-    if (diskfd == -1)
-        err(1, "couldn't open disk");
-
-    blkinfo.sector_size = 512;
-    blkinfo.num_sectors = lseek(diskfd, 0, SEEK_END) / 512;
-    blkinfo.rw = 1;
-
-    printf("Providing disk: %ld sectors @ %d = %ld bytes\n",
-           blkinfo.num_sectors, blkinfo.sector_size,
-           blkinfo.num_sectors * blkinfo.sector_size);
-
-    /* set up virtual network */
-    strcpy(tun_name, netiface);
-    netfd = tun_alloc(tun_name, IFF_TAP | IFF_NO_PI);	/* TAP interface */
-    if (netfd < 0) {
-        perror("Allocating interface");
-        exit(1);
-    }
-    /* generate a random, locally-administered and unicast MAC address */
-    int rfd = open("/dev/urandom", O_RDONLY);
-
-    if (rfd == -1)
-        err(1, "Could not open /dev/urandom");
-    uint8_t guest_mac[6];
-
-    ret = read(rfd, guest_mac, sizeof(guest_mac));
-    assert(ret == sizeof(guest_mac));
-    close(rfd);
-    guest_mac[0] &= 0xfe;
-    guest_mac[0] |= 0x02;
-    snprintf(netinfo.mac_str, sizeof(netinfo.mac_str),
-            "%02x:%02x:%02x:%02x:%02x:%02x",
-            guest_mac[0], guest_mac[1], guest_mac[2],
-            guest_mac[3], guest_mac[4], guest_mac[5]);
-
-    printf("Providing network: %s, guest address %s\n", tun_name,
-            netinfo.mac_str);
 
     kvm = open("/dev/kvm", O_RDWR | O_CLOEXEC);
     if (kvm == -1)
@@ -991,7 +825,7 @@ int main(int argc, char **argv)
     setup_system(vcpufd, mem);
 
     /* Setup ukvm_boot_info and command line */
-    setup_boot_info(mem, GUEST_SIZE, kernel_end, argc, argv);
+    setup_boot_info(mem, GUEST_SIZE, kernel_end, num_args, &first_arg);
 
     /*
      * Initialize registers: instruction pointer for our code, addends,
@@ -1034,17 +868,8 @@ int main(int argc, char **argv)
     if (ret)
         err(1, "couldn't create event thread");
 
-    if (use_gdb) {
-        /* TODO check if we have the KVM_CAP_SET_GUEST_DEBUG capbility */
-        struct kvm_guest_debug debug = {
-            .control = KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_SINGLESTEP,
-        };
+    if (setup_modules(vcpufd, mem))
+        errx(1, "couldn't setup modules");
 
-        if (ioctl(vcpufd, KVM_SET_GUEST_DEBUG, &debug) < 0)
-            printf("KVM_SET_GUEST_DEBUG failed");
-
-        gdb_stub_start(vcpufd);
-    }
-
-    return vcpu_loop(run, vcpufd, mem, diskfd, netfd);
+    return vcpu_loop(run, vcpufd, mem);
 }

--- a/ukvm/ukvm.c
+++ b/ukvm/ukvm.c
@@ -716,10 +716,13 @@ int setup_modules(int vcpufd, uint8_t *mem)
 {
     int i;
 
-    for (i = 0; i < NUM_MODULES; i++)
-        if (modules[i]->setup(vcpufd, mem))
+    for (i = 0; i < NUM_MODULES; i++) {
+        if (modules[i]->setup(vcpufd, mem)) {
+            printf("Please check you have correctly specified:\n %s\n",
+                   modules[i]->usage());
             return -1;
-
+        }
+    }
     return 0;
 }
 

--- a/ukvm/ukvm_config.bash
+++ b/ukvm/ukvm_config.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "a$1" == "a--help" ]; then
+    echo -n "Usage: $0 ["
+    echo -n `ls ukvm-*.c` | sed s/"ukvm-"//g | sed s/"\.c"//g
+    echo "] > Makefile.ukvm"
+    exit
+fi
+
+echo "UKVM_MODULE_OBJS= \\"
+for m in $@; do
+    echo "ukvm-$m.o \\"
+done
+echo 
+echo "UKVM_MODULE_FLAGS= \\"
+for m in $@; do
+    echo "-DUKVM_MODULE_${m^^} \\"
+done
+echo 

--- a/ukvm/ukvm_modules.h
+++ b/ukvm/ukvm_modules.h
@@ -1,0 +1,18 @@
+#ifndef __UKVM_MODULES_H__
+#define __UKVM_MODULES_H__
+
+/* hypercall interfaces exported by modules are in ukvm.h */
+
+struct ukvm_module {
+    int (*get_fd)(void);
+    int (*handle_exit)(struct kvm_run *run, int vcpufd, uint8_t *mem);
+    int (*handle_cmdarg)(char *cmdarg);
+    int (*setup)(int vcpufd, uint8_t *mem);
+    char *(*usage)(void);
+};
+
+extern struct ukvm_module ukvm_blk;
+extern struct ukvm_module ukvm_net;
+extern struct ukvm_module ukvm_gdb;
+
+#endif


### PR DESCRIPTION
This breaks ukvm into a few different modules.  The idea is that it can be built without one or more of the modules, and I'd like to eventually make OPAM know about how to build a monitor for a unikernel based on what it needs.  For the first commit, I'm checking in a ukvm build config (`Makefile.ukvm`) which includes all modules, so functionally everything should stay the same.

This is a bit of an annoying change for a few reasons:
- it moves a bunch of code into different files
- it changes the argument order to `ukvm` yet again (see issue #26 )

This also bumps up on a few things that are changing or will change
- it only supports one instance of each type of device (e.g., net, disk)
- the `poll` code now gets its fd list from the modules (still only net at the moment)