### PR TITLE
malloc() and sbrk() fixes

### DIFF
--- a/kernel/malloc.c
+++ b/kernel/malloc.c
@@ -2,8 +2,7 @@
 
 /* dlmalloc configuration */
 #undef WIN32
-#define ABORT PANIC("aborting...")
-#define MORECORE_CANNOT_TRIM
+#define ABORT PANIC("dlmalloc: aborting...")
 #define HAVE_MMAP 0
 #define HAVE_MREMAP 0
 #define MMAP_CLEARS 0
@@ -21,7 +20,7 @@
 #define LACKS_SCHED_H
 #define LACKS_TIME_H
 #define ABORT_ON_ASSERT_FAILURE 1
-#define MALLOC_FAILURE_ACTION PANIC("out of memory")
+#define MALLOC_FAILURE_ACTION ;
 
 /* return values from posix_memalign() */
 #define ENOMEM -1      /* Out of memory */

--- a/kernel/virtio/mem.c
+++ b/kernel/virtio/mem.c
@@ -71,19 +71,22 @@ void mem_init(struct multiboot_info *mb)
     heap_top = heap_start;
 }
 
-/* for malloc */
+/*
+ * Called by dlmalloc to allocate or free memory.
+ */
 void *sbrk(intptr_t increment)
 {
-    uint64_t ret;
+    uint64_t prev, brk;
+    prev = brk = heap_top;
 
-    if (increment == 0)
-        return (void *)heap_top;
+    /*
+     * dlmalloc guarantees increment values less than half of size_t, so this
+     * is safe from overflow.
+     */
+    brk += increment;
+    if (brk >= max_addr || brk < heap_start)
+        return (void *)-1;
 
-    assert(increment >= PAGE_SIZE);
-    assert((increment % PAGE_SIZE) == 0);
-
-    ret = heap_top;
-    heap_top += increment;
-
-    return (void *)ret;
+    heap_top = brk;
+    return (void *)prev;
 }


### PR DESCRIPTION
- simplify sbrk() code path
- page alignment is not required in sbrk()
- enable giving back memory via sbrk() and tell malloc() about it
- don't abort in malloc() if memory exhausted, instead return NULL which
  should trigger OCaml GC

Related to #58, although does not fundamentally affect the issue.