### PR TITLE
ukvm: Fix overflow if solo5_poll() called too late

### DIFF
--- a/kernel/ukvm/time.c
+++ b/kernel/ukvm/time.c
@@ -38,8 +38,13 @@ uint64_t solo5_clock_wall(void)
 int solo5_poll(uint64_t until_nsecs)
 {
     struct ukvm_poll t;
+    uint64_t now;
 
-    t.until_nsecs = until_nsecs - solo5_clock_monotonic();
+    now = solo5_clock_monotonic();
+    if (until_nsecs <= now)
+        t.until_nsecs = 0;
+    else
+        t.until_nsecs = until_nsecs - now;
     outl(UKVM_PORT_POLL, ukvm_ptr(&t));
     cc_barrier();
     return t.ret;

--- a/ukvm/ukvm.c
+++ b/ukvm/ukvm.c
@@ -693,8 +693,8 @@ void ukvm_port_poll(uint8_t *mem, void *data, int netfd)
     struct pollfd fds = { .fd = netfd, .events = POLLIN };
     int rc;
 
-    ts.tv_sec = t->until_nsecs / 1000000000ULL;
-    ts.tv_nsec = t->until_nsecs % 1000000000ULL;
+    ts.tv_sec = t->timeout_nsecs / 1000000000ULL;
+    ts.tv_nsec = t->timeout_nsecs % 1000000000ULL;
 
     /*
      * Guest execution is blocked during the ppoll() call, note that interrupts

--- a/ukvm/ukvm.h
+++ b/ukvm/ukvm.h
@@ -142,14 +142,14 @@ struct ukvm_netread {
 };
 
 /*
- * UKVM_PORT_POLL: Block until monotonic time reaches until_nsecs or I/O is
- * possible, whichever is sooner. Returns 1 if I/O is possible, otherwise 0.
+ * UKVM_PORT_POLL: Block until timeout_nsecs have passed or I/O is possible,
+ * whichever is sooner. Returns 1 if I/O is possible, otherwise 0.
  *
  * TODO: Extend this interface to select which I/O events are of interest.
  */
 struct ukvm_poll {
     /* IN */
-    uint64_t until_nsecs;
+    uint64_t timeout_nsecs;
 
     /* OUT */
     int ret;


### PR DESCRIPTION
If solo5_poll() on ukvm is called after until_nsecs have passed then we
pass a negative value to UKVM_PORT_POLL which results in waiting for a
very long time.

Also clarify the UKVM_PORT_POLL interface to make it clear that the
timeout is relative, not absolute.